### PR TITLE
Cli parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 wc
 wc.o
 *.sw[po]
+.test-playground/

--- a/wc.c
+++ b/wc.c
@@ -48,7 +48,7 @@ int process_cmdline(int argc, char *argv[]) {
     }
 
     int count_defined = 0;
-    for (int i=2; i < argc; i++) {
+    for (int i = 1; i < argc; i++) {
         if (strcmp("-c", argv[i]) == 0) {
             config.char_counter = true;
             count_defined++;
@@ -66,13 +66,18 @@ int process_cmdline(int argc, char *argv[]) {
             i++;
             config.separator = argv[i][0];
             count_defined++;
+        } else if (argv[i][0] != '-') {
+            config.filename = argv[i];
         } else if (strcmp("-h", argv[i]) == 0) {
             print_help();
             exit(0);
         }
     }
 
-    config.filename = argv[1];
+    if (config.filename == NULL) {
+        fprintf(stderr, "The input file is not specified.\n");
+        return 1;
+    }
 
     if (count_defined != 1) {
       fprintf(stderr, "Only one counter type is allowed in the same time.\n");

--- a/wc.c
+++ b/wc.c
@@ -94,6 +94,13 @@ int main(int argc, char *argv[]) {
 
     FILE *f = fopen(config.filename, "r");
 
+    if (f == NULL) {
+      fprintf(stderr,
+              "The %s file cannot be opened. (Maybe it doesn't exist?)\n",
+              config.filename);
+      return 1;
+    }
+
     // do nothing if no counter is defined
     if (config.char_counter || config.word_counter || config.line_counter
             || config.separator != '\0') {

--- a/wc.c
+++ b/wc.c
@@ -35,9 +35,16 @@ int main(int argc, char *argv[]) {
     }
     FILE *f = fopen(argv[1], "r");
 
+    // character counter
     int c_opt = strcmp("-c", argv[2]) == 0;
+
+    // line counter
     int l_opt = strcmp("-l", argv[2]) == 0;
+
+    // word counter
     int w_opt = strcmp("-w", argv[2]) == 0;
+
+    // counter using the given separator
     int s_opt = strcmp("-s", argv[2]) == 0;
 
     if (c_opt || l_opt || w_opt || s_opt) {

--- a/wc.c
+++ b/wc.c
@@ -8,8 +8,11 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdbool.h>
+
 
 void print_help() {
     printf("wc <filename> [-c | -l | -w | -s] [sep]\n");
@@ -23,41 +26,82 @@ void print_help() {
 }
 
 
-int main(int argc, char *argv[]) {
+struct Configuration {
+    bool char_counter;    // character counter
+    bool line_counter;    // line counter
+    bool word_counter;    // word counter
+
+    char separator;       // define own separator for counting
+    char* filename;       // the file that should be parsed
+} config = {false, false, false, '\0', NULL};
+
+
+int process_cmdline(int argc, char *argv[]) {
     if (argc == 2 && strcmp("-h", argv[1]) == 0) {
         print_help();
-        return 0;
+        exit(0);
     }
 
-    if (!(argc == 3 || (argc == 4 && strcmp("-s", argv[2]) == 0))) {
+    if (argc < 3) {
         fprintf(stderr, "Incorrect number of arguments\n");
         return 1;
     }
-    FILE *f = fopen(argv[1], "r");
 
-    // character counter
-    int c_opt = strcmp("-c", argv[2]) == 0;
+    int count_defined = 0;
+    for (int i=2; i < argc; i++) {
+        if (strcmp("-c", argv[i]) == 0) {
+            config.char_counter = true;
+            count_defined++;
+        } else if (strcmp("-w", argv[i]) == 0) {
+            config.word_counter = true;
+            count_defined++;
+        } else if (strcmp("-l", argv[i]) == 0) {
+            config.line_counter = true;
+            count_defined++;
+        } else if (strcmp("-s", argv[i]) == 0) {
+            if (i+1 >= argc) {
+              fprintf(stderr, "The '-s' option requires argument.\n");
+              return 1;
+            }
+            i++;
+            config.separator = argv[i][0];
+            count_defined++;
+        } else if (strcmp("-h", argv[i]) == 0) {
+            print_help();
+            exit(0);
+        }
+    }
 
-    // line counter
-    int l_opt = strcmp("-l", argv[2]) == 0;
+    config.filename = argv[1];
 
-    // word counter
-    int w_opt = strcmp("-w", argv[2]) == 0;
+    if (count_defined != 1) {
+      fprintf(stderr, "Only one counter type is allowed in the same time.\n");
+      return 1;
+    }
 
-    // counter using the given separator
-    int s_opt = strcmp("-s", argv[2]) == 0;
+    return 0;
+}
 
-    if (c_opt || l_opt || w_opt || s_opt) {
+int main(int argc, char *argv[]) {
+
+    if (process_cmdline(argc, argv))
+        return 1;
+
+    FILE *f = fopen(config.filename, "r");
+
+    // do nothing if no counter is defined
+    if (config.char_counter || config.word_counter || config.line_counter
+            || config.separator != '\0') {
         int i = 0;
         int c;
         while ((c = fgetc(f)) != EOF) {
-            if (l_opt && c == '\n') {
+            if (config.line_counter && c == '\n') {
                 i++;
-            } else if (c_opt) {
+            } else if (config.char_counter) {
                 i++;
-            } else if (w_opt && isspace(c)) {
+            } else if (config.word_counter && isspace(c)) {
                 i++;
-            } else if (s_opt && c == argv[3][0]) {
+            } else if (config.separator && c == config.separator) {
                 i++;
             }
         }

--- a/wc.c
+++ b/wc.c
@@ -49,8 +49,8 @@ int main(int argc, char *argv[]) {
             } else if (c_opt) {
                 i++;
             } else if (w_opt && isspace(c)) {
-	    	i++;
-	    } else if (s_opt && c == argv[3][0]) {
+                i++;
+            } else if (s_opt && c == argv[3][0]) {
                 i++;
             }
         }


### PR DESCRIPTION
Improve the cmdline parsing

Major changes:

* the filename parameter is not positional anymore

  Originally the input filename had to be given as the first parameter
  on the cmdline. The position is not required now. So the filename
  can be specified e.g. on the last position.

* the processed cmdline data is avilable via the `config` global variable

  See the `Configuration` struct


Additional minor changes:

* exit properly when the file cannot be opened (instead of sefgault :eyes: )
* the cmdline is processed inside the `process_cmdline` function
* ignore the *.test-playground* directory

  We decided to create a directory to have a spece where we could put own
  testing data, notes, ... and do not want to make it part of the git repo.
* comment the code better
